### PR TITLE
check: ubuntu compatible interface

### DIFF
--- a/deauthalyzer.py
+++ b/deauthalyzer.py
@@ -5,6 +5,7 @@ import signal
 import sys
 import time
 import datetime
+import threading
 from termcolor import colored
 
 print("\n")
@@ -28,9 +29,15 @@ def check_root_privileges():
 def get_wifi_interfaces():
     interfaces = psutil.net_if_addrs()
     wifi_interfaces = []
-    for interface, addresses in interfaces.items():
-        if interface.startswith('wlan'):
-            wifi_interfaces.append(interface)
+    for interface, _ in interfaces.items():
+        # check interface ubuntu
+        check_interface = subprocess.check_output(['uname', '-a'])
+        if 'Ubuntu' in check_interface.__str__():
+            if interface.startswith('wlp2s0'):
+                wifi_interfaces.append(interface)
+        else:
+            if interface.startswith('wlan0'):
+                wifi_interfaces.append(interface)
     return wifi_interfaces
 
 def enable_monitor_mode(interface, stealth_mode):
@@ -134,4 +141,3 @@ except ValueError:
 selected_interface = wifi_interfaces[interface_num - 1]
 
 detect_deauth_attack(selected_interface, args.stealth)
-

--- a/deauthalyzer.py
+++ b/deauthalyzer.py
@@ -30,14 +30,9 @@ def get_wifi_interfaces():
     interfaces = psutil.net_if_addrs()
     wifi_interfaces = []
     for interface, _ in interfaces.items():
-        # check interface ubuntu
-        check_interface = subprocess.check_output(['uname', '-a'])
-        if 'Ubuntu' in check_interface.__str__():
-            if interface.startswith('wlp2s0'):
-                wifi_interfaces.append(interface)
-        else:
-            if interface.startswith('wlan0'):
-                wifi_interfaces.append(interface)
+        if interface.startswith('wl'):
+           wifi_interfaces.append(interface)
+
     return wifi_interfaces
 
 def enable_monitor_mode(interface, stealth_mode):


### PR DESCRIPTION
When I ran the script on Ubuntu and had a problem with the network interface initially being set to `wlan0`, on my Ubuntu the default network interface is `wlp2s0`.

- Running on ubuntu, in the function `get_wifi_interfaces` the variable `wifi_interfaces` returns an empty list because it doesn't find a valid network interface and consequently breaks the script.

_So i did a simple check on the network interface to avoid new bugs for ubuntu users:_

```python
# check interface ubuntu
check_interface = subprocess.check_output(['uname', '-a'])
if 'Ubuntu' in check_interface.__str__():
    if interface.startswith('wlp2s0'):
        wifi_interfaces.append(interface)
else:
    if interface.startswith('wlan0'):
        wifi_interfaces.append(interface)
```
I hope it solves the problem of other people like me :)